### PR TITLE
add #redirect_to for actual 302 redirects

### DIFF
--- a/lib/rest_spy/api.rb
+++ b/lib/rest_spy/api.rb
@@ -77,6 +77,10 @@ module RestSpy
       CreateProxy.new(redirect_url)
     end
 
+    def redirect_to(redirect_url)
+      CreateDouble.new(302, {'Location' => redirect_url}, '')
+    end
+
     def return_response(body = '', status_code = 200, headers = {})
       CreateDouble.new(status_code, headers, body)
     end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -1,0 +1,25 @@
+require 'rest_spy/api'
+
+module RestSpy
+  describe Api do
+    describe '#redirect_to' do
+      let(:api) { Class.new { extend Api } }
+
+      it 'returns a CreateDouble' do
+        expect(api.redirect_to('http://redirect.url')).to be_instance_of(Api::CreateDouble)
+      end
+
+      it 'configures correct redirect header' do
+        expect(api.redirect_to('http://redirect.url').send(:headers)['Location']).to eq('http://redirect.url')
+      end
+
+      it 'configures correct 302 status code' do
+        expect(api.redirect_to('http://redirect.url').send(:status_code)).to eq(302)
+      end
+
+      it 'configures no body' do
+        expect(api.redirect_to('http://redirect.url').send(:body)).to eq('')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR comes with a fresh :green_apple: and a :pineapple:.

For instance helpful when simulating error situations that should not be wrapped as 500 responses from RestSpy.

I am not proud of the private method testing, but then again, Api wasn't tested from what I could tell, so I didn't feel that bad anymore :p
